### PR TITLE
Allow sending traits to elevio

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,7 +7,10 @@
   "main": "lib/index.js",
   "dependencies": {
     "segmentio/analytics.js-integration": "^1.0.0",
-    "timoxley/next-tick": "0.0.2"
+    "timoxley/next-tick": "0.0.2",
+    "segmentio/obj-case": "~0.2.1",
+    "ndhoule/each": "^1.0.3",
+    "ndhoule/keys": "^1.1.1"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.10.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,10 @@
+'use strict';
+
 var integration = require('analytics.js-integration');
 var tick = require('next-tick');
+var objCase = require('segmentio-obj-case');
+var each = require('ndhoule-each');
+var objectKeys = require('ndhoule-keys');
 
 /**
  * Expose `Elevio` integration.
@@ -45,12 +50,21 @@ Elevio.prototype.identify = function(identify) {
   var name = identify.name();
   var email = identify.email();
   var plan = identify.proxy('traits.plan');
+  var traits = identify.traits();
+
+  var removeTraits = ['id', 'name', 'firstName', 'lastName', 'email'];
+
+  each(function(traitItem) {
+    if (traits.hasOwnProperty(traitItem)) {
+      objCase.del(traits, traitItem);
+    }
+  }, removeTraits);
 
   var user = {};
   user.via = 'segment';
   if (email) user.email = email;
   if (name) user.name = name;
   if (plan) user.plan = [plan];
-
+  if (objectKeys(traits).length > 0) user.traits = traits;
   window._elev.user = user;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Analytics = require('analytics.js-core').constructor;
 var integration = require('analytics.js-integration');
 var tester = require('analytics.js-integration-tester');
@@ -103,6 +105,25 @@ describe('Elevio', function() {
         analytics.identify('id', { plan: 'gold' });
         analytics.assert(window._elev.user.plan instanceof Array);
         analytics.assert(window._elev.user.plan[0] === 'gold');
+      });
+
+      it('should send traits when custrom keys are provided', function() {
+        analytics.identify('id', { locale: 'en_US' });
+        analytics.assert(window._elev.user.traits instanceof Object);
+        analytics.assert(window._elev.user.traits.hasOwnProperty('locale'));
+        analytics.assert(window._elev.user.traits.locale === 'en_US');
+      });
+
+      it('should not send traits when no trait information is present', function() {
+        analytics.identify('id', { firstName: 'Test', lastName: 'Person', email: 'test@email.com' });
+        analytics.assert(!(window._elev.user.traits instanceof Object));
+      });
+
+      it('should remove reserved keys from the trait if without removing unreserved keys', function() {
+        analytics.identify('id', { firstName: 'Test', locale: 'en_US' });
+        analytics.assert(window._elev.user.traits instanceof Object);
+        analytics.assert(!window._elev.user.traits.hasOwnProperty('firstName'));
+        analytics.assert(window._elev.user.traits.locale === 'en_US');
       });
     });
   });


### PR DESCRIPTION
This is a resubmit of PR #1

I wasn't' able to do a clean rebase, since there was already pushed conflicting changes spread between the rebased tags, so found it easier to create a new branch and manually move the updates over.

Previous 2 commits rolled into this one: 
Small update to allow the sending through of traits through to elevio, so they can be used for article access control.

Also includes requested updates from the original PR
